### PR TITLE
Change the UserInfo to always take from user_metadata

### DIFF
--- a/src/integrationTest/java/uk/co/dajohnston/houseworkapi/userinfo/UserInfoTest.java
+++ b/src/integrationTest/java/uk/co/dajohnston/houseworkapi/userinfo/UserInfoTest.java
@@ -28,7 +28,6 @@ class UserInfoTest {
                     """
                         {
                           "email": "housework-api-integration-tests@dajohnston.co.uk",
-                          "name": "Integration Tests",
                           "firstName": null,
                           "lastName": null,
                           "nickname": "housework-api-integration-tests",

--- a/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0User.java
+++ b/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0User.java
@@ -1,3 +1,9 @@
 package uk.co.dajohnston.houseworkapi.userinfo.auth0;
 
-public record Auth0User(String email, String name, String nickname, String picture, Auth0UserMetaData user_metadata) {}
+public record Auth0User(
+    String given_name,
+    String family_name,
+    String email,
+    String nickname,
+    String picture,
+    Auth0UserMetaData user_metadata) {}

--- a/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserInfoMapper.java
+++ b/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserInfoMapper.java
@@ -6,11 +6,21 @@ import uk.co.dajohnston.houseworkapi.userinfo.model.UserInfoDTO;
 
 @Mapper
 public interface Auth0UserInfoMapper {
-  @Mapping(target = "firstName", source = "user_metadata.first_name")
-  @Mapping(target = "lastName", source = "user_metadata.last_name")
+  @Mapping(
+      target = "firstName",
+      source = "user_metadata.firstName",
+      defaultExpression = "java(auth0User.given_name())")
+  @Mapping(
+      target = "lastName",
+      source = "user_metadata.lastName",
+      defaultExpression = "java(auth0User.family_name())")
   @Mapping(
       target = "nickname",
       source = "user_metadata.nickname",
       defaultExpression = "java(auth0User.nickname())")
+  @Mapping(
+      target = "picture",
+      source = "user_metadata.picture",
+      defaultExpression = "java(auth0User.picture())")
   UserInfoDTO toUserInfoDTO(Auth0User auth0User);
 }

--- a/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserMetaData.java
+++ b/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserMetaData.java
@@ -1,3 +1,4 @@
 package uk.co.dajohnston.houseworkapi.userinfo.auth0;
 
-public record Auth0UserMetaData(String first_name, String last_name, String nickname) {}
+public record Auth0UserMetaData(
+    String firstName, String lastName, String nickname, String picture) {}

--- a/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/model/UserInfoDTO.java
+++ b/src/main/java/uk/co/dajohnston/houseworkapi/userinfo/model/UserInfoDTO.java
@@ -1,9 +1,4 @@
 package uk.co.dajohnston.houseworkapi.userinfo.model;
 
 public record UserInfoDTO(
-    String email,
-    String name,
-    String firstName,
-    String lastName,
-    String nickname,
-    String picture) {}
+    String email, String firstName, String lastName, String nickname, String picture) {}

--- a/src/test/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserInfoServiceTest.java
+++ b/src/test/java/uk/co/dajohnston/houseworkapi/userinfo/auth0/Auth0UserInfoServiceTest.java
@@ -57,7 +57,8 @@ class Auth0UserInfoServiceTest {
 
   @Test
   void getUserInfo_setsFirstNameFromMetaData() {
-    Auth0User auth0User = new Auth0User("", "", "", "", new Auth0UserMetaData("David", "", ""));
+    Auth0User auth0User =
+        new Auth0User("Joe", "", "", "", "", new Auth0UserMetaData("David", "", "", ""));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =
@@ -67,8 +68,21 @@ class Auth0UserInfoServiceTest {
   }
 
   @Test
+  void getUserInfo_setsFirstNameFromGivenNameWhenNotSetInMetaData() {
+    Auth0User auth0User =
+        new Auth0User("Joe", "", "", "", "", new Auth0UserMetaData(null, "", "", ""));
+    when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
+
+    UserInfoDTO userInfo =
+        new Auth0UserInfoService(webClient, getMapper(Auth0UserInfoMapper.class)).getUserInfo("");
+
+    assertThat(userInfo.firstName(), is("Joe"));
+  }
+
+  @Test
   void getUserInfo_setsLastNameFromMetaData() {
-    Auth0User auth0User = new Auth0User("", "", "", "", new Auth0UserMetaData("", "Johnston", ""));
+    Auth0User auth0User =
+        new Auth0User("", "Bloggs", "", "", "", new Auth0UserMetaData("", "Johnston", "", ""));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =
@@ -78,8 +92,21 @@ class Auth0UserInfoServiceTest {
   }
 
   @Test
-  void getUserInfo_setsNicknameFromMetaData_whenPresent() {
-    Auth0User auth0User = new Auth0User("", "", "Dave", "", new Auth0UserMetaData("", "", "DJ"));
+  void getUserInfo_setsLastNameFromFamilyNameWhenNotSetInMetaData() {
+    Auth0User auth0User =
+        new Auth0User("", "Bloggs", "", "", "", new Auth0UserMetaData("", null, "", ""));
+    when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
+
+    UserInfoDTO userInfo =
+        new Auth0UserInfoService(webClient, getMapper(Auth0UserInfoMapper.class)).getUserInfo("");
+
+    assertThat(userInfo.lastName(), is("Bloggs"));
+  }
+
+  @Test
+  void getUserInfo_setsNicknameFromMetaData() {
+    Auth0User auth0User =
+        new Auth0User("", "", "", "Dave", "", new Auth0UserMetaData("", "", "DJ", ""));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =
@@ -90,7 +117,8 @@ class Auth0UserInfoServiceTest {
 
   @Test
   void getUserInfo_setsNicknameFromTopLevel_whenNotPresentInMetaData() {
-    Auth0User auth0User = new Auth0User("", "", "Dave", "", new Auth0UserMetaData("", "", null));
+    Auth0User auth0User =
+        new Auth0User("", "", "", "Dave", "", new Auth0UserMetaData("", "", null, ""));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =
@@ -100,19 +128,9 @@ class Auth0UserInfoServiceTest {
   }
 
   @Test
-  void getUserInfo_setsNameFromTopLevel() {
-    Auth0User auth0User = new Auth0User("", "David Johnston", "", "", null);
-    when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
-
-    UserInfoDTO userInfo =
-        new Auth0UserInfoService(webClient, getMapper(Auth0UserInfoMapper.class)).getUserInfo("");
-
-    assertThat(userInfo.name(), is("David Johnston"));
-  }
-
-  @Test
   void getUserInfo_setsEmailFromTopLevel() {
-    Auth0User auth0User = new Auth0User("david@test.com", "", "", "", null);
+    Auth0User auth0User =
+        new Auth0User("", "", "david@test.com", "", "", new Auth0UserMetaData("", "", "", ""));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =
@@ -122,8 +140,28 @@ class Auth0UserInfoServiceTest {
   }
 
   @Test
-  void getUserInfo_setsPictureFromTopLevel() {
-    Auth0User auth0User = new Auth0User("", "", "", "https://picture.com", null);
+  void getUserInfo_setsPictureFromMetaData() {
+    Auth0User auth0User =
+        new Auth0User(
+            "",
+            "",
+            "",
+            "",
+            "https://picture.com",
+            new Auth0UserMetaData("", "", "", "https://picture-meta.com"));
+    when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
+
+    UserInfoDTO userInfo =
+        new Auth0UserInfoService(webClient, getMapper(Auth0UserInfoMapper.class)).getUserInfo("");
+
+    assertThat(userInfo.picture(), is("https://picture-meta.com"));
+  }
+
+  @Test
+  void getUserInfo_setsPictureFromTopLevel_whenNotPresentInMetaData() {
+    Auth0User auth0User =
+        new Auth0User(
+            "", "", "", "", "https://picture.com", new Auth0UserMetaData("", "", "", null));
     when(responseSpec.bodyToMono(Auth0User.class)).thenReturn(just(auth0User));
 
     UserInfoDTO userInfo =

--- a/src/test/java/uk/co/dajohnston/houseworkapi/userinfo/controller/UserInfoControllerTest.java
+++ b/src/test/java/uk/co/dajohnston/houseworkapi/userinfo/controller/UserInfoControllerTest.java
@@ -35,7 +35,6 @@ class UserInfoControllerTest {
         .thenReturn(
             new UserInfoDTO(
                 "email@test.com",
-                "David Johnston",
                 "David",
                 "Johnston",
                 "DJ",
@@ -51,7 +50,6 @@ class UserInfoControllerTest {
                           "firstName": "David",
                           "lastName": "Johnston",
                           "email": "email@test.com",
-                          "name": "David Johnston",
                           "nickname": "DJ",
                           "picture": "https://picture.com"
                         }


### PR DESCRIPTION
Given we can't update values at the top level for social users we should always set the data in the user-metadata and fall back to the top level if the user has never updated their info.